### PR TITLE
implement url shortener, add MapStore impl

### DIFF
--- a/internal/db/map_store.go
+++ b/internal/db/map_store.go
@@ -1,0 +1,53 @@
+package db
+
+// In-memory implementtation of URLStore.
+// Intended for testing purposes.
+
+type stringMap map[string]string
+
+type MapStore struct {
+	entries stringMap
+}
+
+// Returns a new BoltStore instance with its connection open.
+func NewMapStore() *MapStore {
+	return &MapStore{
+		entries: make(stringMap),
+	}
+}
+
+// Set sets a shorten url and its key
+// Note: Caller is responsible to generate a key.
+func (s *MapStore) Set(key string, value string) error {
+	s.entries[key] = value
+	return nil
+}
+
+// Clear clears all the database entries for the table urls.
+func (d *MapStore) Clear() error {
+	d.entries = make(stringMap)
+	return nil
+}
+
+// Get returns a url by its key.
+// Returns an empty string if not found.
+func (s *MapStore) Get(key string) (value string) {
+	value, found := s.entries[key]
+	if found {
+		return value
+	}
+	return ""
+}
+
+// GetByValue returns all keys for a specific (original) url value.
+func (d *MapStore) GetByValue(value string) []string {
+	return []string{}
+}
+
+// Len returns the number of shortcuts saved
+func (s *MapStore) Len() int {
+	return len(s.entries)
+}
+
+func (s *MapStore) Close() {
+}

--- a/internal/db/map_store_test.go
+++ b/internal/db/map_store_test.go
@@ -1,0 +1,24 @@
+package db
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+const testKey = "key";
+const testValue = "value";
+
+func TestSetGetClear(t *testing.T) {
+	store := NewMapStore();
+
+	err := store.Set(testKey, testValue);
+	assert.Nil(t, err)
+	assert.Equal(t, 1, store.Len())
+
+	value := store.Get(testKey)
+	assert.Equal(t, testValue, value)
+
+	err = store.Clear()
+	assert.Nil(t, err)
+	assert.Equal(t, 0, store.Len())
+}

--- a/internal/rest/api_response.go
+++ b/internal/rest/api_response.go
@@ -1,0 +1,8 @@
+package rest
+
+type DataObject map[string]interface{}
+
+type ApiResponse struct {
+	StatusCode int
+	Data       DataObject
+}

--- a/internal/server/configuration.go
+++ b/internal/server/configuration.go
@@ -3,25 +3,29 @@ package server
 type StoreType int
 
 const DefaultServerPort = "9090"
+const DefaultStoreConnectionString = "none"
 
 /*
  * Lynx will use a store to manage shortened URLs.
  * Bolt is good for testing. DynamoDB and Postgres are needed for deployments.
  */
 const (
-	BoltStore StoreType = iota
-	DynamoStore
-	PgStore
+	BoltStoreType StoreType = iota
+	DynamoStoretype
+	MapStoreType
+	PgStoreType
 )
 
 type Configuration struct {
-	StoreType StoreType
-	Port      string
+	StoreType             StoreType
+	StoreConnectionString string
+	Port                  string
 }
 
 func DefaultConfiguration() *Configuration {
 	return &Configuration{
-		StoreType: BoltStore,
-		Port:      DefaultServerPort,
+		StoreType:             MapStoreType,
+		StoreConnectionString: DefaultStoreConnectionString,
+		Port:                  DefaultServerPort,
 	}
 }

--- a/internal/server/configuration_test.go
+++ b/internal/server/configuration_test.go
@@ -1,14 +1,15 @@
 package server
 
-import(
-  "testing"
+import (
+	"testing"
 
-  "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfiguration(t *testing.T) {
-  config := DefaultConfiguration()
+	config := DefaultConfiguration()
 
-  assert.Equal(t, BoltStore, config.StoreType)
-  assert.Equal(t, DefaultServerPort, config.Port)
+	assert.Equal(t, MapStoreType, config.StoreType)
+	assert.Equal(t, DefaultStoreConnectionString, config.StoreConnectionString)
+	assert.Equal(t, DefaultServerPort, config.Port)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	testUrl := "http://somewhere.over.rainbows/"
+	shortcode := "oz"
 	config := DefaultConfiguration()
 	server := NewLynxServer(config)
 
@@ -14,4 +16,12 @@ func TestServer(t *testing.T) {
 
 	e.GET("/test").Expect().
 		Status(httptest.StatusNotFound)
+
+	e.POST("/api/shorten").
+		WithFormField("url", testUrl).
+		WithFormField("shortcode", shortcode).Expect().
+		Status(httptest.StatusOK).Body().Contains("{\"shortUrl\":")
+
+	e.GET("/u/" + shortcode).Expect().
+		Status(httptest.StatusTemporaryRedirect).Header("Location").Equal(testUrl)
 }

--- a/internal/shortcuts/controller.go
+++ b/internal/shortcuts/controller.go
@@ -1,0 +1,75 @@
+package shortcuts
+
+import (
+	"lynx/internal/db"
+	"lynx/internal/rest"
+
+	"github.com/kataras/iris/v12"
+)
+
+type stringMap map[string]string
+
+type Controller struct {
+	factory *Factory
+	store   db.URLStore
+	vhost   string
+}
+
+func NewController(vhost string, store db.URLStore) *Controller {
+	return &Controller{
+		factory: NewFactory(HashingGenerator),
+		store:   store,
+		vhost:   vhost,
+	}
+}
+
+func (c Controller) Shorten(urlString string, shortcode string) *rest.ApiResponse {
+	if len(urlString) == 0 {
+		return buildApiError(
+			iris.StatusLengthRequired,
+			"Empty parameter `url`.",
+		)
+	}
+
+	if !c.factory.isValid(urlString) {
+		return buildApiError(
+			iris.StatusBadRequest,
+			"Not a valid URL.",
+		)
+	}
+	if len(shortcode) <= 0 {
+		shortcode, _ = c.factory.gen(urlString)
+	}
+	if err := c.store.Set(shortcode, urlString); err != nil {
+		return buildApiError(
+			iris.StatusInternalServerError,
+			"Internal error while saving the URL.",
+		)
+	}
+
+	shortUrl := "http://" + c.vhost + "/u/" + shortcode
+	return buildOkResponse(
+		rest.DataObject{
+			"shortUrl":  shortUrl,
+			"shortcode": shortcode,
+		},
+	)
+}
+
+func buildApiError(code int, description string) *rest.ApiResponse {
+	return &rest.ApiResponse{
+		StatusCode: code,
+		Data: rest.DataObject{
+			"error": rest.DataObject{
+				"description": description,
+			},
+		},
+	}
+}
+
+func buildOkResponse(data rest.DataObject) *rest.ApiResponse {
+	return &rest.ApiResponse{
+		StatusCode: 200,
+		Data:       data,
+	}
+}

--- a/internal/shortcuts/controller_test.go
+++ b/internal/shortcuts/controller_test.go
@@ -1,0 +1,56 @@
+package shortcuts
+
+import (
+	"lynx/internal/db"
+	"lynx/internal/rest"
+
+	"testing"
+	"github.com/kataras/iris/v12"
+	"github.com/stretchr/testify/assert"
+)
+
+const testUrl1 = "https://www.reddit.com/"
+const testUrl2 = "https://www.discord.com/"
+const emptyString = ""
+
+func makeTestController() *Controller {
+	return NewController("shorten.server.test", db.NewMapStore())
+}
+
+func assertValidShortcodeResponse(t *testing.T, response *rest.ApiResponse) string {
+	assert.Equal(t, 200, response.StatusCode)
+	assert.NotNil(t, response.Data["shortUrl"])
+	return response.Data["shortcode"].(string);
+}
+
+func TestShorten(t *testing.T) {
+	controller := makeTestController()
+
+	response := controller.Shorten(testUrl1, emptyString)
+	shortcode := assertValidShortcodeResponse(t, response)
+	assert.Equal(t, shortcodeLength, len(shortcode))
+
+	similarResponse := controller.Shorten(testUrl1, emptyString)
+	assert.Equal(t, shortcode, assertValidShortcodeResponse(t, similarResponse))
+	assert.Equal(t, 1, controller.store.Len())
+
+	differentResponse := controller.Shorten(testUrl2, emptyString)
+	assert.NotEqual(t, shortcode, assertValidShortcodeResponse(t, differentResponse))
+	assert.Equal(t, 2, controller.store.Len())
+}
+
+func TestShortenWithShortcode(t *testing.T) {
+	testShortcode := "reddit"
+	controller := makeTestController()
+
+	response := controller.Shorten(testUrl1, testShortcode)
+	shortcode := assertValidShortcodeResponse(t, response)
+	assert.Equal(t, testShortcode, shortcode)
+}
+
+func TestShortenInvalidUrlReturnsError(t *testing.T) {
+	controller := makeTestController()
+
+	response := controller.Shorten("abc", "")
+	assert.Equal(t, iris.StatusBadRequest, response.StatusCode)
+}

--- a/internal/shortcuts/factory.go
+++ b/internal/shortcuts/factory.go
@@ -1,0 +1,50 @@
+package shortcuts
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"net/url"
+)
+
+// Generator the type to generate keys(short urls)
+type Generator func(uri string) string
+
+const shortcodeLength = 9;
+
+// HashingGenerator is the defautl url generator
+var HashingGenerator = func(uriString string) string {
+	hasher := sha1.New()
+	hasher.Write([]byte(uriString))
+	sha := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+
+	return sha[0:shortcodeLength]
+}
+
+// Factory is responsible to generate keys(short urls)
+type Factory struct {
+	generator Generator
+}
+
+// NewFactory receives a generator and a store and returns a new url Factory.
+func NewFactory(generator Generator) *Factory {
+	return &Factory{
+		generator: generator,
+	}
+}
+
+func (f *Factory) isValid(uriString string) bool {
+	_, err := url.ParseRequestURI(uriString)
+	return err == nil
+}
+
+// Gen generates the key.
+func (f *Factory) gen(uriString string) (string, error) {
+	uri, err := url.ParseRequestURI(uriString)
+	if err != nil {
+		return "", err
+	}
+
+	// use the normalized, parsed string to generate a key
+	key := f.generator(uri.String())
+	return key, nil
+}

--- a/internal/shortcuts/factory_test.go
+++ b/internal/shortcuts/factory_test.go
@@ -1,0 +1,24 @@
+package shortcuts
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateShortcode(t *testing.T) {
+	factory := NewFactory(HashingGenerator)
+
+	code, err := factory.gen(testUrl1)
+	assert.Nil(t, err)
+	assert.Equal(t, shortcodeLength, len(code))
+}
+
+func TestBasicUrlIsValid(t *testing.T) {
+	factory := NewFactory(HashingGenerator)
+	assert.Equal(t, true, factory.isValid(testUrl1))
+}
+
+func TestNonUrlIsNotValid(t *testing.T) {
+	factory := NewFactory(HashingGenerator)
+	assert.Equal(t, false, factory.isValid("abc"))
+}


### PR DESCRIPTION
1. Implements a basic memory-backed URLStore, suitable for test purposes: MapStore
2. Adds `shortcuts` packages with Controller class to implement URL shortener functionality for LynxServer